### PR TITLE
Feature/describe plugin with behat

### DIFF
--- a/behat.yml
+++ b/behat.yml
@@ -1,0 +1,5 @@
+default:
+    suites:
+        core_features:
+            paths:    [ %paths.base%/features/core ]
+            contexts: [ CoreDomainContext ]

--- a/composer.json
+++ b/composer.json
@@ -8,7 +8,8 @@
         "phpspec/phpspec": "~2.1",
         "phpunit/phpunit": "~4.6",
         "mockery/mockery": "0.9.*",
-        "behat/behat": "~3.0"
+        "behat/behat": "~3.0",
+        "bossa/phpspec2-expect": "dev-master"
     },
     "type": "library",
     "config": {

--- a/composer.json
+++ b/composer.json
@@ -1,7 +1,8 @@
 {
     "name": "amacgregor/triplecheck-phpcs",
     "require": {
-        "adambrett/shell-wrapper": "*"
+        "adambrett/shell-wrapper": "*",
+        "amacgregor/triplecheck-common": "dev-feature/static-class"
     },
     "require-dev": {
         "phpspec/phpspec": "~2.1",
@@ -19,6 +20,12 @@
             "Triplecheck\\Phpcs\\": "src/" 
         }
     },
+    "repositories": [
+      {
+        "type": "vcs",
+        "url": "git@github.com:DemacMedia/triplecheck-common.git"
+      }
+    ],
     "authors": [
         {
             "name": "Allan MacGregor",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at http://getcomposer.org/doc/01-basic-usage.md#composer-lock-the-lock-file",
         "This file is @generated automatically"
     ],
-    "hash": "ec06b5437ae81c6ec71f96f3d541e36f",
+    "hash": "b49a3e86c97693899bf96a0c59b188e9",
     "packages": [
         {
             "name": "adambrett/shell-wrapper",
@@ -275,6 +275,52 @@
                 "transliterator"
             ],
             "time": "2014-05-15 22:08:22"
+        },
+        {
+            "name": "bossa/phpspec2-expect",
+            "version": "dev-master",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/BossaConsulting/phpspec2-expect.git",
+                "reference": "f3a80b7fa743b8a1078a7e320bd3e8b8b6283780"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/BossaConsulting/phpspec2-expect/zipball/f3a80b7fa743b8a1078a7e320bd3e8b8b6283780",
+                "reference": "f3a80b7fa743b8a1078a7e320bd3e8b8b6283780",
+                "shasum": ""
+            },
+            "require": {
+                "phpspec/phpspec": "~2.0"
+            },
+            "type": "library",
+            "autoload": {
+                "files": [
+                    "expect.php"
+                ],
+                "psr-0": {
+                    "Bossa\\PhpSpec\\Expect\\": ""
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Marcello Duarte",
+                    "homepage": "http://marcelloduarte.net/"
+                }
+            ],
+            "description": "Helper that decorates any SUS with a phpspec lazy object wrapper",
+            "keywords": [
+                "BDD",
+                "SpecBDD",
+                "TDD",
+                "spec",
+                "specification"
+            ],
+            "time": "2014-09-12 09:25:51"
         },
         {
             "name": "doctrine/instantiator",
@@ -1948,7 +1994,8 @@
     "aliases": [],
     "minimum-stability": "stable",
     "stability-flags": {
-        "amacgregor/triplecheck-common": 20
+        "amacgregor/triplecheck-common": 20,
+        "bossa/phpspec2-expect": 20
     },
     "prefer-stable": false,
     "prefer-lowest": false,

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at http://getcomposer.org/doc/01-basic-usage.md#composer-lock-the-lock-file",
         "This file is @generated automatically"
     ],
-    "hash": "b92b8eba9dcb46ed2e41655799b2ad81",
+    "hash": "ec06b5437ae81c6ec71f96f3d541e36f",
     "packages": [
         {
             "name": "adambrett/shell-wrapper",
@@ -49,6 +49,51 @@
             ],
             "description": "An object oriented wrapper for shell commands",
             "time": "2014-10-16 12:55:02"
+        },
+        {
+            "name": "amacgregor/triplecheck-common",
+            "version": "dev-feature/static-class",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/DemacMedia/triplecheck-common.git",
+                "reference": "a7e6efa5d4cb1c3c61bb45e2567db578d99b00f5"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/DemacMedia/triplecheck-common/zipball/a7e6efa5d4cb1c3c61bb45e2567db578d99b00f5",
+                "reference": "a7e6efa5d4cb1c3c61bb45e2567db578d99b00f5",
+                "shasum": ""
+            },
+            "require": {
+                "adambrett/shell-wrapper": "*"
+            },
+            "require-dev": {
+                "behat/behat": "~3.0",
+                "mockery/mockery": "0.9.*",
+                "phpspec/phpspec": "~2.1",
+                "phpunit/phpunit": "~4.6"
+            },
+            "type": "library",
+            "autoload": {
+                "psr-0": {
+                    "Triplecheck\\Common\\": "src/",
+                    "Triplecheck\\Phpcs\\": "../triplecheck-phpcs/src/"
+                },
+                "classmap": [
+                    "src/Triplecheck/Triplecheck.php"
+                ]
+            },
+            "authors": [
+                {
+                    "name": "Allan MacGregor",
+                    "email": "amacgregor@allanmacgregor.com"
+                }
+            ],
+            "support": {
+                "source": "https://github.com/DemacMedia/triplecheck-common/tree/feature/static-class",
+                "issues": "https://github.com/DemacMedia/triplecheck-common/issues"
+            },
+            "time": "2015-04-19 01:56:04"
         }
     ],
     "packages-dev": [
@@ -1902,7 +1947,9 @@
     ],
     "aliases": [],
     "minimum-stability": "stable",
-    "stability-flags": [],
+    "stability-flags": {
+        "amacgregor/triplecheck-common": 20
+    },
     "prefer-stable": false,
     "prefer-lowest": false,
     "platform": [],

--- a/features/bootstrap/CoreDomainContext.php
+++ b/features/bootstrap/CoreDomainContext.php
@@ -5,6 +5,7 @@ use Behat\Behat\Context\Context;
 use Behat\Behat\Context\SnippetAcceptingContext;
 use Behat\Gherkin\Node\PyStringNode;
 use Behat\Gherkin\Node\TableNode;
+use PHPUnit_Framework_Assert as assert;
 
 /**
  * Defines application features from the specific context.

--- a/features/bootstrap/CoreDomainContext.php
+++ b/features/bootstrap/CoreDomainContext.php
@@ -1,0 +1,40 @@
+<?php
+
+use Behat\Behat\Tester\Exception\PendingException;
+use Behat\Behat\Context\Context;
+use Behat\Behat\Context\SnippetAcceptingContext;
+use Behat\Gherkin\Node\PyStringNode;
+use Behat\Gherkin\Node\TableNode;
+
+/**
+ * Defines application features from the specific context.
+ */
+class CoreDomainContext implements Context, SnippetAcceptingContext
+{
+    private $folderPath;
+
+    /**
+     * @Given I have a module located in :folderPath
+     *
+     */
+    public function iHaveAModuleLocatedIn($folderPath)
+    {
+        $this->folderPath = $folderPath;
+    }
+
+    /**
+     * @When I run triple-check
+     */
+    public function iRunTripleCheck()
+    {
+        throw new PendingException();
+    }
+
+    /**
+     * @Then I should see that the score for this extension should be scored :arg1
+     */
+    public function iShouldSeeThatTheScoreForThisExtensionShouldBeScored($arg1)
+    {
+        throw new PendingException();
+    }
+}

--- a/features/core/run-command.feature
+++ b/features/core/run-command.feature
@@ -1,0 +1,10 @@
+Feature: As a developer who is passionate about quality
+  In order to see how good my extension code is
+  As a passionate developer
+  I need to be able to run triple check and see a score and info about my Magento extension
+
+  Scenario: I can get a score based on my extension I am developing
+    Given I have a module located in "features/fixtures/sample-extension"
+    When I run triple-check
+    Then I should see that the score for this extension should be scored "4"
+


### PR DESCRIPTION
This is still WIP but Behat is configured ready to be used to model the core domain with the core domain context. so we can run `behat --suite=core_features`
